### PR TITLE
Rework homepage animation to a faster one

### DIFF
--- a/src/components/app/app.css
+++ b/src/components/app/app.css
@@ -1,3 +1,3 @@
 .app {
-  display: flex;
+  display: block;
 }

--- a/src/components/app/app.js
+++ b/src/components/app/app.js
@@ -105,7 +105,6 @@ class App extends React.Component {
     });
   }
   handleKeyPress(event: Object) { // TODO: maybe export this functionality to another file
-    event.preventDefault();
     const {
       isSelectedSidePanel,
       isSelectedHomeContainer,
@@ -117,6 +116,7 @@ class App extends React.Component {
     if (goToEpisode) return;
     switch (event.key) {
       case 'ArrowLeft':
+        event.preventDefault();
         if (isSelectedHomeContainer && selectedEpisode === 0) {
           this.setState({
             isSelectedHomeContainer: false,
@@ -130,6 +130,7 @@ class App extends React.Component {
         }
         break;
       case 'ArrowRight':
+        event.preventDefault();
         if (isSelectedSidePanel) {
           this.setState({
             isSelectedHomeContainer: true,
@@ -146,6 +147,7 @@ class App extends React.Component {
         }
         break;
       case 'ArrowUp':
+        event.preventDefault();
         this.resetSelectedEpisode();
         if (isSelectedHomeContainer && selectedSeries !== 0) {
           this.setState({
@@ -154,6 +156,7 @@ class App extends React.Component {
         }
         break;
       case 'ArrowDown':
+        event.preventDefault();
         this.resetSelectedEpisode();
         if (isSelectedHomeContainer && selectedSeries !== series.length - 1) {
           this.setState({
@@ -162,6 +165,7 @@ class App extends React.Component {
         }
         break;
       case 'Enter':
+        event.preventDefault();
         if (isSelectedHomeContainer) {
           this.setState({
             goToEpisode: true,
@@ -169,6 +173,7 @@ class App extends React.Component {
         }
         break;
       case 'Backspace':
+        event.preventDefault();
         if (isSelectedHomeContainer) {
           this.resetSelectedEpisode();
         }

--- a/src/components/app/app.js
+++ b/src/components/app/app.js
@@ -114,7 +114,7 @@ class App extends React.Component {
       goToEpisode,
     } = this.state;
     if (goToEpisode) return;
-    switch (event.key) {
+    switch (event.code) {
       case 'ArrowLeft':
         event.preventDefault();
         if (isSelectedHomeContainer && selectedEpisode === 0) {

--- a/src/components/app/app.test.js
+++ b/src/components/app/app.test.js
@@ -61,7 +61,7 @@ jest.mock('../home-container/home-container', () =>
 
 function connectEvent(event, type, wrapper, handleFunction) {
   const changedEvent: Object = event;
-  changedEvent.key = type;
+  changedEvent.code = type;
   const app: Object = wrapper.instance();
   if (handleFunction === 'handleKeyPress') {
     app.handleKeyPress(event);

--- a/src/components/episode-selected/episode-selected.js
+++ b/src/components/episode-selected/episode-selected.js
@@ -42,7 +42,7 @@ class episodeSelected extends React.Component {
     const {
       closePopupFunction,
     } = this.props;
-    switch (event.key) {
+    switch (event.code) {
       case 'ArrowUp':
         if (closePopupFunction) closePopupFunction(event);
         break;

--- a/src/components/episode-selected/episode-selected.test.js
+++ b/src/components/episode-selected/episode-selected.test.js
@@ -14,7 +14,7 @@ jest.mock('../video-player-container/parts/video-player', () =>
 
 function connectEvent(event, type, wrapper) {
   const changedEvent: Object = event;
-  changedEvent.key = type;
+  changedEvent.code = type;
   const episodeSelected: Object = wrapper.instance();
   episodeSelected.handleKeyPress(event);
 }

--- a/src/components/home-container/__snapshots__/home-container.test.js.snap
+++ b/src/components/home-container/__snapshots__/home-container.test.js.snap
@@ -3,6 +3,11 @@
 exports[`HomeContainer:  renders correctly with data and goToEpisode prop enabled 1`] = `
 <div
   className="home-container"
+  style={
+    Object {
+      "transform": "translate(0px, -320px)",
+    }
+  }
 >
   <div>
     Slider
@@ -22,6 +27,11 @@ exports[`HomeContainer:  renders correctly with data and goToEpisode prop enable
 exports[`HomeContainer:  renders correctly with data but without goToEpisode enabled 1`] = `
 <div
   className="home-container"
+  style={
+    Object {
+      "transform": "translate(0px, -320px)",
+    }
+  }
 >
   <div>
     Slider

--- a/src/components/home-container/home-container.css
+++ b/src/components/home-container/home-container.css
@@ -1,14 +1,17 @@
 
 :root {
-  --slider--top-offset: -285px;
+  --home-container--margin-left: 100px;
+  --home-container--padding: 20px;
+  --slider-height: 320px;
+  --home-container--transition-duration: 0.3s;
+  --home-container--font-size: 2em;
 }
 
 .home {
   &-container {
-    overflow-x: hidden;
-    overflow-y: hidden;
-    height: 100vh;
-    padding-top: 20px;
+    margin-left: var(--home-container--margin-left);
+    padding: var(--home-container--padding) 0;
+    transition-duration: var(--home-container--transition-duration);
   }
 
   & > div {
@@ -18,18 +21,10 @@
 
   &-slider {
     font-family: 'Oxygen', sans-serif;
-    font-size: 2em;
+    font-size: var(--home-container--font-size);
     margin-top: 0;
-    padding: 20px;
+    padding: var(--home-container--padding);
+    height: var(--slider-height);
     padding-bottom: 0;
-    transition: margin-top 0.1s;
-  }
-
-  &-slider--top-offset {
-    margin-top: var(--slider--top-offset);
-  }
-
-  &-slider--top-hidden {
-    opacity: 0;
   }
 }

--- a/src/components/home-container/home-container.js
+++ b/src/components/home-container/home-container.js
@@ -44,15 +44,17 @@ class HomeContainer extends React.Component { // eslint-disable-line react/prefe
           sliderTitle={data.title}
           key={data.title}
           isSelected={isSelected && index === selectedSeries}
-          isBeforeSelected={index === selectedSeries - 1}
-          isHidden={index < selectedSeries - 1}
           selectedEpisode={selectedEpisode}
         />
       ),
     );
     if (goToEpisode) homePageContent.splice(selectedSeries + 1, 0, episodeDetailsContainer);
+    const verticalOffset = -320;
     return (
-      <div className="home-container">
+      <div
+        className="home-container"
+        style={{ transform: `translate(0px, ${selectedSeries * verticalOffset}px)` }}
+      >
         {homePageContent}
       </div>
     );

--- a/src/components/side-panel/side-panel.css
+++ b/src/components/side-panel/side-panel.css
@@ -6,9 +6,10 @@
 }
 
 .side-panel {
-  flex: 0 1 auto;
+  position: fixed;
+  z-index: 1;
   width: var(--side-panel-width);
-  height: 100vh;
+  height: 100%;
   background-color: var(--economist-red, red);
   transition: width 0.2s ease-out;
 

--- a/src/components/slider/__snapshots__/slider.test.js.snap
+++ b/src/components/slider/__snapshots__/slider.test.js.snap
@@ -11,6 +11,11 @@ exports[`Slider renders correctly 1`] = `
   </div>
   <div
     className="slider-items"
+    style={
+      Object {
+        "transform": "translate(-1240px, 0px)",
+      }
+    }
   >
     <div>
       SliderItem
@@ -27,7 +32,7 @@ exports[`Slider renders correctly 1`] = `
 
 exports[`Slider renders correctly 2`] = `
 <div
-  className="home-slider home-slider--top-offset home-slider--top-hidden"
+  className="home-slider"
 >
   <div
     className="slider-title"
@@ -36,6 +41,11 @@ exports[`Slider renders correctly 2`] = `
   </div>
   <div
     className="slider-items"
+    style={
+      Object {
+        "transform": "translate(0px, 0px)",
+      }
+    }
   >
     <div>
       SliderItem
@@ -61,6 +71,11 @@ exports[`Slider renders correctly 3`] = `
   </div>
   <div
     className="slider-items"
+    style={
+      Object {
+        "transform": "translate(0px, 0px)",
+      }
+    }
   >
     <div>
       SliderItem

--- a/src/components/slider/parts/__snapshots__/slider-item.test.js.snap
+++ b/src/components/slider/parts/__snapshots__/slider-item.test.js.snap
@@ -1,10 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SliderItem renders correctly 1`] = `
-<a
+<div
   className="slider-item"
-  onClick={[Function]}
-  style={Object {}}
 >
   <img
     alt="Episode 6 Title"
@@ -25,14 +23,12 @@ exports[`SliderItem renders correctly 1`] = `
       subtitle
     </div>
   </div>
-</a>
+</div>
 `;
 
 exports[`SliderItem renders correctly 2`] = `
-<a
-  className="slider-item slider-item--left-offset"
-  onClick={[Function]}
-  style={Object {}}
+<div
+  className="slider-item"
 >
   <img
     alt="Series 1 Title"
@@ -53,14 +49,12 @@ exports[`SliderItem renders correctly 2`] = `
       10 episodes
     </div>
   </div>
-</a>
+</div>
 `;
 
 exports[`SliderItem renders correctly 3`] = `
-<a
+<div
   className="slider-item slider-item--selected"
-  onClick={[Function]}
-  style={Object {}}
 >
   <img
     alt="Episode 19 Title"
@@ -81,5 +75,5 @@ exports[`SliderItem renders correctly 3`] = `
       subtitle
     </div>
   </div>
-</a>
+</div>
 `;

--- a/src/components/slider/parts/slider-item.css
+++ b/src/components/slider/parts/slider-item.css
@@ -1,10 +1,9 @@
 @import '../../../colors.css';
 
 :root {
-  --slider-item-width: 250px;
-  --slider-left-offset: -260px;
+  --slider-item-width: 300px;
   --slider-item-margin-right: 10px;
-  --slider-item-image-height: 137px;
+  --slider-item-image-height: 165px;
   --container-padding: 10px;
 }
 
@@ -23,10 +22,6 @@
     opacity: 0.5;
     cursor: pointer;
     transition: opacity 0.3s;
-  }
-
-  &--left-offset {
-    margin-left: var(--slider-left-offset);
   }
 
   &__image {

--- a/src/components/slider/parts/slider-item.js
+++ b/src/components/slider/parts/slider-item.js
@@ -1,7 +1,6 @@
 // @flow
 import React from 'react';
 import classnames from 'classnames';
-import { Link } from 'react-router';
 import SliderItemType from '../../../structures/sliderItem';
 import './slider-item.css';
 
@@ -21,24 +20,19 @@ class SliderItem extends React.Component { // eslint-disable-line react/prefer-s
     const {
       title,
       subtitle,
-      id,
       thumbnail,
       type,
       episode_count: episodeCount,
       className,
       isSelected,
-      isBeforeSelected,
-      isSelectedSeries,
     } = this.props;
     const sliderItemClassName = classnames(
       { [`${className}`]: true },
       { [`${className}--selected`]: isSelected },
-      { [`${className}--left-offset`]: isSelectedSeries && isBeforeSelected },
     );
     return (
-      <Link
+      <div
         className={sliderItemClassName}
-        to={`/episode/${id}`}
       >
         <img
           src={SliderItem.setTeaserImage(thumbnail)}
@@ -51,7 +45,7 @@ class SliderItem extends React.Component { // eslint-disable-line react/prefer-s
             {SliderItem.isItemSeries(type) ? `${String(episodeCount)} episodes` : subtitle}
           </div>
         </div>
-      </Link>
+      </div>
     );
   }
 }

--- a/src/components/slider/slider.css
+++ b/src/components/slider/slider.css
@@ -1,5 +1,9 @@
 @import '../../colors.css';
 
+:root {
+  --slider-items--transition-duration: 0.3s;
+}
+
 .slider {
   &-title {
     display: block;
@@ -10,6 +14,6 @@
 
   &-items {
     display: flex;
-    overflow-x: auto;
+    transition-duration: var(--slider-items--transition-duration);
   }
 }

--- a/src/components/slider/slider.js
+++ b/src/components/slider/slider.js
@@ -17,27 +17,27 @@ class Slider extends React.Component { // eslint-disable-line react/prefer-state
       isSelected,
       className,
       sliderTitle,
-      isBeforeSelected,
-      isHidden,
       selectedEpisode,
     } = this.props;
     const sliderClassName = classnames(
       { [`${className}`]: true },
       { [`${className}--selected`]: isSelected },
-      { [`${className}--top-offset`]: isBeforeSelected || isHidden },
-      { [`${className}--top-hidden`]: isHidden },
     );
+    const horizontalOffset = -310;
+    const calcOffset = isSelected ? selectedEpisode * horizontalOffset : 0;
     return (
-      <div className={sliderClassName}>
+      <div className={sliderClassName} >
         <div className="slider-title">{sliderTitle}</div>
-        <div className="slider-items">
+        <div
+          className="slider-items"
+          style={{ transform: `translate(${calcOffset}px, 0px)` }}
+        >
           {this.props.data.map((item, index) =>
             <SliderItem
               {...item}
               key={item.title}
               className="slider-item"
               isSelectedSeries={isSelected}
-              isBeforeSelected={index < selectedEpisode}
               isSelected={isSelected && index === selectedEpisode}
             />,
           )}

--- a/src/components/video-player-container/parts/video-player.js
+++ b/src/components/video-player-container/parts/video-player.js
@@ -93,7 +93,7 @@ class VideoPlayer extends React.Component {
     document.removeEventListener('keydown', this.handleKeyPress);
   }
   handleKeyPress(event: KeyboardEvent) {
-    switch (event.key) {
+    switch (event.code) {
       case 'ArrowUp':
         (this: any).setState({
           isBackButtonSelected: true,

--- a/src/components/video-player-container/parts/video-player.test.js
+++ b/src/components/video-player-container/parts/video-player.test.js
@@ -77,7 +77,7 @@ test('Test functions', () => {
 });
 function connectEvent(event, type, wrapper) {
   const changedEvent: Object = event;
-  changedEvent.key = type;
+  changedEvent.code = type;
   const app: Object = wrapper.instance();
   app.handleKeyPress(event);
 }


### PR DESCRIPTION
This PR includes #50 and #47 from our Trello board.
The main purpose was to change the way we move are tiles on the homepage so we don't cause unnecessary CPU drainage. The new animations are done by CSS `transform: translate`.
The #47 was about using the prop `code` instead of `key` for the `keyboardEvent`.