### PR TITLE
series page

### DIFF
--- a/src/components/app/app.js
+++ b/src/components/app/app.js
@@ -169,8 +169,8 @@ class App extends React.Component {
         event.preventDefault();
         if (isSelectedHomeContainer) {
           if (series[selectedSeries].items[selectedEpisode].type === 'Series') {
-            const selectedSeries1 = series[selectedSeries].series_id;
-            browserHistory.push(`/series/${selectedSeries1}`);
+            const seriesId = series[selectedSeries].series_id;
+            browserHistory.push(`/series/${seriesId}`);
           } else {
             this.setState({
               goToEpisode: true,
@@ -214,6 +214,7 @@ class App extends React.Component {
           selectedEpisode={selectedEpisode}
           goToEpisode={goToEpisode}
           closePopupFunction={this.handleReturnFromEpisode}
+          isSelectedHomeContainer={isSelectedHomeContainer}
         />
       </div>
     );

--- a/src/components/app/app.js
+++ b/src/components/app/app.js
@@ -1,5 +1,6 @@
 // @flow
 import React from 'react';
+import { browserHistory } from 'react-router';
 import SidePanel from '../side-panel/side-panel';
 import { getRoot, getRecommendedEpisodes } from '../../api/fetch';
 import HomeContainer from '../home-container/home-container';
@@ -167,9 +168,13 @@ class App extends React.Component {
       case 'Enter':
         event.preventDefault();
         if (isSelectedHomeContainer) {
-          this.setState({
-            goToEpisode: true,
-          });
+          if (selectedEpisode === 0) {
+            browserHistory.push(`/series/${this.state.selectedSeries}`);
+          } else {
+            this.setState({
+              goToEpisode: true,
+            });
+          }
         }
         break;
       case 'Backspace':

--- a/src/components/app/app.js
+++ b/src/components/app/app.js
@@ -168,8 +168,9 @@ class App extends React.Component {
       case 'Enter':
         event.preventDefault();
         if (isSelectedHomeContainer) {
-          if (selectedEpisode === 0) {
-            browserHistory.push(`/series/${this.state.selectedSeries}`);
+          if (series[selectedSeries].items[selectedEpisode].type === 'Series') {
+            const selectedSeries1 = series[selectedSeries].series_id;
+            browserHistory.push(`/series/${selectedSeries1}`);
           } else {
             this.setState({
               goToEpisode: true,

--- a/src/components/app/app.test.js
+++ b/src/components/app/app.test.js
@@ -8,6 +8,11 @@ const mockData = [
     title: 'Ocean',
     items: [
       {
+        id: 0,
+        title: 'zzz',
+        type: 'Series',
+      },
+      {
         id: 1,
         title: 'xxx',
         type: 'Episode',
@@ -77,6 +82,8 @@ describe('App: ', () => {
     expect(app.state().isSelectedHomeContainer).toEqual(true);
     app.setState({ series: mockData });
     const event = new Event('keyDown');
+    // no functionaility, just need to cover all branches, default switch
+    connectEvent(event, 'Shift', app, 'handleKeyPress');
     // we have the first episode of the first series selected [0,0]
     // we select the second episode of the first series [0,1]
     connectEvent(event, 'ArrowRight', app, 'handleKeyPress');
@@ -96,6 +103,7 @@ describe('App: ', () => {
     // we try the upper bounds
     connectEvent(event, 'ArrowUp', app, 'handleKeyPress');
     expect(app.state().selectedSeries).toEqual(0);
+    connectEvent(event, 'Enter', app, 'handleKeyPress');
     connectEvent(event, 'ArrowRight', app, 'handleKeyPress');
     expect(app.state().selectedEpisode).toEqual(1);
     // the Backspace button resets the selected episode
@@ -116,6 +124,9 @@ describe('App: ', () => {
     expect(app.state().selectedEpisode).toEqual(1);
     connectEvent(event, 'ArrowLeft', app, 'handleKeyPress');
     expect(app.state().selectedEpisode).toEqual(0);
+    connectEvent(event, 'ArrowRight', app, 'handleKeyPress');
+    connectEvent(event, 'Enter', app, 'handleKeyPress');
+    expect(app.state().goToEpisode).toEqual(true);
     // no functionaility, just need to cover all branches, default switch
     connectEvent(event, 'Shift', app, 'handleKeyPress');
     connectEvent(event, 'Enter', app, 'handleKeyPress');

--- a/src/components/episode-selected/__snapshots__/episode-selected.test.js.snap
+++ b/src/components/episode-selected/__snapshots__/episode-selected.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`HomeContainer:  renders with data 1`] = `
+exports[`HomeContainer  renders with data 1`] = `
 <div
   className="episode-selected"
 >

--- a/src/components/episode-selected/__snapshots__/episode-selected.test.js.snap
+++ b/src/components/episode-selected/__snapshots__/episode-selected.test.js.snap
@@ -25,13 +25,11 @@ exports[`HomeContainer  renders with data 1`] = `
     <div
       className="episode-buttons"
     >
-      <a
+      <div
         className="episode-buttons__learn"
-        onClick={[Function]}
-        style={Object {}}
       >
         Learn More
-      </a>
+      </div>
     </div>
   </div>
 </div>

--- a/src/components/episode-selected/episode-selected.css
+++ b/src/components/episode-selected/episode-selected.css
@@ -11,6 +11,8 @@
   --video-teaser-height: 350px;
   --video-teaser-blur: 5px;
   --video-button-width: 100px;
+  --opacityUnselect: 0.5;
+  --opacitySelect: 1;
 }
 
 .episode-selected {
@@ -26,11 +28,11 @@
     left: calc(50% - var(--video-button-width) / 2);
     cursor: pointer;
     transition: opacity 0.3s;
-    opacity: 0.5;
+    opacity: var(--opacityUnselect);
   }
 
   &__image--selected {
-    opacity: 1;
+    opacity: var(--opacitySelect);
   }
 
   &__teaser-wrapper {
@@ -71,6 +73,7 @@
     background-color: var(--economist-red);
     color: var(--economist-white);
     transition: background-color 0.3s;
+    opacity: var(--opacityUnselect);
   }
 
   &__watch--selected,
@@ -78,7 +81,7 @@
   &__watch:hover,
   &__learn:hover {
     cursor: pointer;
-    background-color: #88120b;
+    opacity: var(--opacitySelect);
   }
 
   &__watch {

--- a/src/components/episode-selected/episode-selected.js
+++ b/src/components/episode-selected/episode-selected.js
@@ -15,6 +15,7 @@ type EpisodeSelectedType = {
   description: string,
   closePopupFunction: ?Function,
   videoUrl: string,
+  seriesId: number,
 };
 
 class episodeSelected extends React.Component {
@@ -64,7 +65,12 @@ class episodeSelected extends React.Component {
         if (closePopupFunction) closePopupFunction(event);
         break;
       case 'Enter':
-        browserHistory.push(`/watch/${this.props.id}`);
+        if (selectedItem === 1) {
+          browserHistory.push(`/watch/${this.props.id}`);
+        }
+        if (selectedItem === 2) {
+          browserHistory.push(`/series/${this.props.seriesId}?expandedEpisode=${this.props.id}`);
+        }
         break;
       default:
     }
@@ -78,11 +84,12 @@ class episodeSelected extends React.Component {
       title,
       description,
       videoUrl,
+      seriesId,
     } = this.props;
     const {
       selectedItem,
     } = this.state;
-    const learnString = `/learn?id=${id}`;
+    const learnString = `/series/${seriesId}?expandedEpisode=${id}`;
     const imageClassName = classnames(
       'episode-selected__image',
       { 'episode-selected__image--selected': selectedItem === 0 },

--- a/src/components/episode-selected/episode-selected.js
+++ b/src/components/episode-selected/episode-selected.js
@@ -13,16 +13,17 @@ type EpisodeSelectedType = {
   title: string,
   subtitle: string,
   description: string,
-  closePopupFunction: ?Function,
+  closePopupFunction: Function,
   videoUrl: string,
   seriesId: number,
+  isSelectedHomeContainer: boolean,
 };
 
 class episodeSelected extends React.Component {
   constructor() {
     super();
     this.state = {
-      selectedItem: 0,
+      selectedItem: 1,
     };
     (this: any).handleKeyPress = this.handleKeyPress.bind(this);
   }
@@ -42,27 +43,32 @@ class episodeSelected extends React.Component {
     } = this.state;
     const {
       closePopupFunction,
+      isSelectedHomeContainer,
     } = this.props;
     switch (event.code) {
       case 'ArrowUp':
-        if (closePopupFunction) closePopupFunction(event);
+        closePopupFunction(event);
         break;
       case 'ArrowLeft':
-        if (selectedItem > 0) {
-          this.setState({
-            selectedItem: selectedItem - 1,
-          });
+        if (isSelectedHomeContainer) {
+          if (selectedItem > 1) {
+            this.setState({
+              selectedItem: selectedItem - 1,
+            });
+          }
         }
         break;
       case 'ArrowRight':
-        if (selectedItem < 2) {
-          this.setState({
-            selectedItem: selectedItem + 1,
-          });
+        if (isSelectedHomeContainer) {
+          if (selectedItem < 2) {
+            this.setState({
+              selectedItem: selectedItem + 1,
+            });
+          }
         }
         break;
       case 'Backspace':
-        if (closePopupFunction) closePopupFunction(event);
+        closePopupFunction(event);
         break;
       case 'Enter':
         if (selectedItem === 1) {
@@ -85,6 +91,7 @@ class episodeSelected extends React.Component {
       description,
       videoUrl,
       seriesId,
+      isSelectedHomeContainer,
     } = this.props;
     const {
       selectedItem,
@@ -92,8 +99,19 @@ class episodeSelected extends React.Component {
     const learnString = `/series/${seriesId}?expandedEpisode=${id}`;
     const imageClassName = classnames(
       'episode-selected__image',
-      { 'episode-selected__image--selected': selectedItem === 0 },
+      { 'episode-selected__image--selected': selectedItem === 1 },
     );
+    const learnMoreButton = isSelectedHomeContainer ? (
+      <Link
+        className={classnames(
+          'episode-buttons__learn',
+          { 'episode-buttons__learn--selected': selectedItem === 2 },
+        )}
+        to={learnString}
+      >
+      Learn More
+    </Link>
+  ): null;
     return (
       <div className="episode-selected">
         <div className="episode-selected__teaser-wrapper">
@@ -112,15 +130,7 @@ class episodeSelected extends React.Component {
             className="episode-description-wrapper"
           />
           <div className="episode-buttons">
-            <Link
-              className={classnames(
-                'episode-buttons__learn',
-                { 'episode-buttons__learn--selected': selectedItem === 2 },
-              )}
-              to={learnString}
-            >
-              Learn More
-            </Link>
+            {learnMoreButton}
           </div>
         </div>
       </div>

--- a/src/components/episode-selected/episode-selected.js
+++ b/src/components/episode-selected/episode-selected.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import { browserHistory, Link } from 'react-router';
+import { browserHistory } from 'react-router';
 import classnames from 'classnames';
 import EpisodeDescription from './parts/episode-description';
 import VideoPlayer from '../video-player-container/parts/video-player';
@@ -23,7 +23,7 @@ class episodeSelected extends React.Component {
   constructor() {
     super();
     this.state = {
-      selectedItem: 1,
+      selectedItem: 0,
     };
     (this: any).handleKeyPress = this.handleKeyPress.bind(this);
   }
@@ -44,6 +44,8 @@ class episodeSelected extends React.Component {
     const {
       closePopupFunction,
       isSelectedHomeContainer,
+      seriesId,
+      id,
     } = this.props;
     switch (event.code) {
       case 'ArrowUp':
@@ -51,7 +53,7 @@ class episodeSelected extends React.Component {
         break;
       case 'ArrowLeft':
         if (isSelectedHomeContainer) {
-          if (selectedItem > 1) {
+          if (selectedItem > 0) {
             this.setState({
               selectedItem: selectedItem - 1,
             });
@@ -60,7 +62,7 @@ class episodeSelected extends React.Component {
         break;
       case 'ArrowRight':
         if (isSelectedHomeContainer) {
-          if (selectedItem < 2) {
+          if (selectedItem < 1) {
             this.setState({
               selectedItem: selectedItem + 1,
             });
@@ -71,11 +73,11 @@ class episodeSelected extends React.Component {
         closePopupFunction(event);
         break;
       case 'Enter':
-        if (selectedItem === 1) {
-          browserHistory.push(`/watch/${this.props.id}`);
+        if (selectedItem === 0) {
+          browserHistory.push(`/watch/${id}`);
         }
-        if (selectedItem === 2) {
-          browserHistory.push(`/series/${this.props.seriesId}?expandedEpisode=${this.props.id}`);
+        if (selectedItem === 1) {
+          browserHistory.push(`/series/${seriesId}?expandedEpisode=${id}`);
         }
         break;
       default:
@@ -90,27 +92,23 @@ class episodeSelected extends React.Component {
       title,
       description,
       videoUrl,
-      seriesId,
       isSelectedHomeContainer,
     } = this.props;
     const {
       selectedItem,
     } = this.state;
-    const learnString = `/series/${seriesId}?expandedEpisode=${id}`;
-    const imageClassName = classnames(
-      'episode-selected__image',
-      { 'episode-selected__image--selected': selectedItem === 1 },
-    );
+    const playButtonClassName = classnames({
+      'episode-selected__image': true,
+      'episode-selected__image--selected': selectedItem === 0,
+    });
+    const learnMoreButtonClassname = classnames({
+      'episode-buttons__learn': true,
+      'episode-buttons__learn--selected': selectedItem === 1,
+    });
     const learnMoreButton = isSelectedHomeContainer ? (
-      <Link
-        className={classnames(
-          'episode-buttons__learn',
-          { 'episode-buttons__learn--selected': selectedItem === 2 },
-        )}
-        to={learnString}
-      >
+      <div className={learnMoreButtonClassname} >
       Learn More
-    </Link>
+    </div>
   ): null;
     return (
       <div className="episode-selected">
@@ -122,7 +120,7 @@ class episodeSelected extends React.Component {
             isMuted
             videoID={id}
           />
-          <img className={imageClassName} src={PlayLogo} alt={title} />
+          <img className={playButtonClassName} src={PlayLogo} alt={title} />
         </div>
         <div className="episode-selected__info-container">
           <EpisodeDescription

--- a/src/components/episode-selected/episode-selected.test.js
+++ b/src/components/episode-selected/episode-selected.test.js
@@ -29,6 +29,7 @@ describe('HomeContainer: ', () => {
       description="description xyz"
       closePopupFunction={() => {}}
       videoUrl=""
+      seriesId={7}
     />).toJSON();
     expect(tree).toMatchSnapshot();
   });
@@ -41,15 +42,18 @@ describe('HomeContainer: ', () => {
       description="description xyz"
       closePopupFunction={() => {}}
       videoUrl=""
+      seriesId={7}
     />);
     const event = new Event('keyDown');
     expect(episodeSelected.state().selectedItem).toEqual(0);
     connectEvent(event, 'ArrowRight', episodeSelected);
     expect(episodeSelected.state().selectedItem).toEqual(1);
     connectEvent(event, 'ArrowRight', episodeSelected);
+    connectEvent(event, 'Enter', episodeSelected);
     expect(episodeSelected.state().selectedItem).toEqual(2);
     connectEvent(event, 'ArrowRight', episodeSelected);
     expect(episodeSelected.state().selectedItem).toEqual(2);
+    connectEvent(event, 'Enter', episodeSelected);
     connectEvent(event, 'ArrowLeft', episodeSelected);
     expect(episodeSelected.state().selectedItem).toEqual(1);
     connectEvent(event, 'Enter', episodeSelected);
@@ -68,6 +72,7 @@ describe('HomeContainer: ', () => {
       description="description xyz"
       closePopupFunction={null}
       videoUrl=""
+      seriesId={7}
     />);
     connectEvent(event, 'ArrowUp', episodeSelected);
     connectEvent(event, 'Backspace', episodeSelected);
@@ -81,6 +86,7 @@ describe('HomeContainer: ', () => {
       description="description xyz"
       closePopupFunction={() => {}}
       videoUrl=""
+      seriesId={7}
     />);
     wrapper.unmount();
   });

--- a/src/components/episode-selected/episode-selected.test.js
+++ b/src/components/episode-selected/episode-selected.test.js
@@ -48,15 +48,15 @@ describe('HomeContainer ', () => {
     />);
     const event = new Event('keyDown');
     // when home container is selected and there are 2 buttons
-    expect(episodeSelected.state().selectedItem).toEqual(1);
+    expect(episodeSelected.state().selectedItem).toEqual(0);
     connectEvent(event, 'Shift', episodeSelected);
     connectEvent(event, 'ArrowRight', episodeSelected);
-    expect(episodeSelected.state().selectedItem).toEqual(2);
+    expect(episodeSelected.state().selectedItem).toEqual(1);
     connectEvent(event, 'ArrowRight', episodeSelected);
-    expect(episodeSelected.state().selectedItem).toEqual(2);
+    expect(episodeSelected.state().selectedItem).toEqual(1);
     connectEvent(event, 'Enter', episodeSelected);
     connectEvent(event, 'ArrowLeft', episodeSelected);
-    expect(episodeSelected.state().selectedItem).toEqual(1);
+    expect(episodeSelected.state().selectedItem).toEqual(0);
     connectEvent(event, 'ArrowLeft', episodeSelected);
     connectEvent(event, 'Enter', episodeSelected);
     connectEvent(event, 'ArrowUp', episodeSelected);
@@ -65,7 +65,7 @@ describe('HomeContainer ', () => {
     connectEvent(event, 'Backspace', episodeSelected);
     // when home container is unselected and there is just 1 button
     episodeSelected.setState({ isSelectedHomeContainer: false });
-    expect(episodeSelected.state().selectedItem).toEqual(2);
+    expect(episodeSelected.state().selectedItem).toEqual(1);
     connectEvent(event, 'Enter', episodeSelected);
     connectEvent(event, 'ArrowLeft', episodeSelected);
     connectEvent(event, 'Enter', episodeSelected);
@@ -86,7 +86,7 @@ describe('HomeContainer ', () => {
     />);
     const event = new Event('keyDown');
     // when home container is unselected and there is just 1 button
-    expect(episodeSelected.state().selectedItem).toEqual(1);
+    expect(episodeSelected.state().selectedItem).toEqual(0);
     connectEvent(event, 'Enter', episodeSelected);
     connectEvent(event, 'ArrowLeft', episodeSelected);
     connectEvent(event, 'Enter', episodeSelected);
@@ -107,7 +107,7 @@ describe('HomeContainer ', () => {
     />);
     const event = new Event('keyDown');
     // when home container is unselected and there is just 1 button
-    expect(episodeSelected.state().selectedItem).toEqual(1);
+    expect(episodeSelected.state().selectedItem).toEqual(0);
     connectEvent(event, 'ArrowUp', episodeSelected);
     connectEvent(event, 'Backspace', episodeSelected);
   });

--- a/src/components/episode-selected/episode-selected.test.js
+++ b/src/components/episode-selected/episode-selected.test.js
@@ -19,61 +19,95 @@ function connectEvent(event, type, wrapper) {
   episodeSelected.handleKeyPress(event);
 }
 
-describe('HomeContainer: ', () => {
+describe('HomeContainer ', () => {
   test('renders with data', () => {
     const tree : string = renderer.create(<EpisodeSelected
       id={3}
-      url="url xyz"
+      url="https://cdn.twivel.io/uploads/economist/episode/thumbnail/141/episode_875X480.jpg"
       title="title xyz"
       subtitle="subtitle xyz"
       description="description xyz"
       closePopupFunction={() => {}}
-      videoUrl=""
+      videoUrl="https://cdn-films.economist.com/OCEANS/OCEANDEEP.m3u8"
       seriesId={7}
+      isSelectedHomeContainer
     />).toJSON();
     expect(tree).toMatchSnapshot();
   });
-  test('handles keyboard events', () => {
-    let episodeSelected = mount(<EpisodeSelected
+  test('handles keyboard events when homeContainer is selected', () => {
+    const episodeSelected = mount(<EpisodeSelected
       id={3}
-      url="url xyz"
+      url="https://cdn.twivel.io/uploads/economist/episode/thumbnail/141/episode_875X480.jpg"
       title="title xyz"
       subtitle="subtitle xyz"
       description="description xyz"
       closePopupFunction={() => {}}
-      videoUrl=""
+      videoUrl="https://cdn-films.economist.com/OCEANS/OCEANDEEP.m3u8"
       seriesId={7}
+      isSelectedHomeContainer
     />);
     const event = new Event('keyDown');
-    expect(episodeSelected.state().selectedItem).toEqual(0);
-    connectEvent(event, 'ArrowRight', episodeSelected);
+    // when home container is selected and there are 2 buttons
     expect(episodeSelected.state().selectedItem).toEqual(1);
-    connectEvent(event, 'ArrowRight', episodeSelected);
-    connectEvent(event, 'Enter', episodeSelected);
-    expect(episodeSelected.state().selectedItem).toEqual(2);
-    connectEvent(event, 'ArrowRight', episodeSelected);
-    expect(episodeSelected.state().selectedItem).toEqual(2);
-    connectEvent(event, 'Enter', episodeSelected);
-    connectEvent(event, 'ArrowLeft', episodeSelected);
-    expect(episodeSelected.state().selectedItem).toEqual(1);
-    connectEvent(event, 'Enter', episodeSelected);
-    connectEvent(event, 'ArrowLeft', episodeSelected);
-    expect(episodeSelected.state().selectedItem).toEqual(0);
-    connectEvent(event, 'ArrowLeft', episodeSelected);
-    expect(episodeSelected.state().selectedItem).toEqual(0);
-    connectEvent(event, 'ArrowUp', episodeSelected);
-    connectEvent(event, 'Backspace', episodeSelected);
     connectEvent(event, 'Shift', episodeSelected);
-    episodeSelected = mount(<EpisodeSelected
+    connectEvent(event, 'ArrowRight', episodeSelected);
+    expect(episodeSelected.state().selectedItem).toEqual(2);
+    connectEvent(event, 'ArrowRight', episodeSelected);
+    expect(episodeSelected.state().selectedItem).toEqual(2);
+    connectEvent(event, 'Enter', episodeSelected);
+    connectEvent(event, 'ArrowLeft', episodeSelected);
+    expect(episodeSelected.state().selectedItem).toEqual(1);
+    connectEvent(event, 'ArrowLeft', episodeSelected);
+    connectEvent(event, 'Enter', episodeSelected);
+    connectEvent(event, 'ArrowUp', episodeSelected);
+    connectEvent(event, 'Enter', episodeSelected);
+    connectEvent(event, 'ArrowRight', episodeSelected);
+    connectEvent(event, 'Backspace', episodeSelected);
+    // when home container is unselected and there is just 1 button
+    episodeSelected.setState({ isSelectedHomeContainer: false });
+    expect(episodeSelected.state().selectedItem).toEqual(2);
+    connectEvent(event, 'Enter', episodeSelected);
+    connectEvent(event, 'ArrowLeft', episodeSelected);
+    connectEvent(event, 'Enter', episodeSelected);
+    connectEvent(event, 'ArrowRight', episodeSelected);
+    connectEvent(event, 'Backspace', episodeSelected);
+  });
+  test('handles keyboard events when homeContainer is unslected', () => {
+    const episodeSelected = mount(<EpisodeSelected
       id={3}
-      url="url xyz"
+      url="https://cdn.twivel.io/uploads/economist/episode/thumbnail/141/episode_875X480.jpg"
       title="title xyz"
       subtitle="subtitle xyz"
       description="description xyz"
-      closePopupFunction={null}
-      videoUrl=""
+      closePopupFunction={() => {}}
+      videoUrl="https://cdn-films.economist.com/OCEANS/OCEANDEEP.m3u8"
       seriesId={7}
+      isSelectedHomeContainer={false}
     />);
+    const event = new Event('keyDown');
+    // when home container is unselected and there is just 1 button
+    expect(episodeSelected.state().selectedItem).toEqual(1);
+    connectEvent(event, 'Enter', episodeSelected);
+    connectEvent(event, 'ArrowLeft', episodeSelected);
+    connectEvent(event, 'Enter', episodeSelected);
+    connectEvent(event, 'ArrowRight', episodeSelected);
+    connectEvent(event, 'Backspace', episodeSelected);
+  });
+  test('handles keyboard events without closePopupFunction', () => {
+    const episodeSelected = mount(<EpisodeSelected
+      id={3}
+      url="https://cdn.twivel.io/uploads/economist/episode/thumbnail/141/episode_875X480.jpg"
+      title="title xyz"
+      subtitle="subtitle xyz"
+      description="description xyz"
+      videoUrl="https://cdn-films.economist.com/OCEANS/OCEANDEEP.m3u8"
+      seriesId={7}
+      isSelectedHomeContainer
+      closePopupFunction={() => {}}
+    />);
+    const event = new Event('keyDown');
+    // when home container is unselected and there is just 1 button
+    expect(episodeSelected.state().selectedItem).toEqual(1);
     connectEvent(event, 'ArrowUp', episodeSelected);
     connectEvent(event, 'Backspace', episodeSelected);
   });
@@ -87,6 +121,7 @@ describe('HomeContainer: ', () => {
       closePopupFunction={() => {}}
       videoUrl=""
       seriesId={7}
+      isSelectedHomeContainer
     />);
     wrapper.unmount();
   });

--- a/src/components/home-container/home-container.js
+++ b/src/components/home-container/home-container.js
@@ -11,7 +11,8 @@ class HomeContainer extends React.Component { // eslint-disable-line react/prefe
     selectedSeries: number,
     selectedEpisode: number,
     goToEpisode: boolean,
-    closePopupFunction: ?Function,
+    closePopupFunction: Function,
+    isSelectedHomeContainer: boolean,
   };
   render() {
     const {
@@ -21,6 +22,7 @@ class HomeContainer extends React.Component { // eslint-disable-line react/prefe
       selectedEpisode,
       goToEpisode,
       closePopupFunction,
+      isSelectedHomeContainer,
     } = this.props;
     if (!series[0]) return null;
     const selectedEpisodeData = series[selectedSeries].items[selectedEpisode];
@@ -35,6 +37,7 @@ class HomeContainer extends React.Component { // eslint-disable-line react/prefe
         closePopupFunction={closePopupFunction}
         videoUrl={selectedEpisodeData.video_url}
         seriesId={selectedEpisodeData.series_id}
+        isSelectedHomeContainer={isSelectedHomeContainer}
       />
     ) : null;
     const homePageContent = series.map((data, index) =>

--- a/src/components/home-container/home-container.js
+++ b/src/components/home-container/home-container.js
@@ -34,6 +34,7 @@ class HomeContainer extends React.Component { // eslint-disable-line react/prefe
         description={selectedEpisodeData.description}
         closePopupFunction={closePopupFunction}
         videoUrl={selectedEpisodeData.video_url}
+        seriesId={selectedEpisodeData.series_id}
       />
     ) : null;
     const homePageContent = series.map((data, index) =>

--- a/src/components/home-container/home-container.test.js
+++ b/src/components/home-container/home-container.test.js
@@ -72,6 +72,7 @@ describe('HomeContainer: ', () => {
         selectedEpisode={0}
         goToEpisode={false}
         closePopupFunction={() => {}}
+        isSelectedHomeContainer={false}
       />,
     ).toJSON();
     expect(tree).toMatchSnapshot();
@@ -85,6 +86,7 @@ describe('HomeContainer: ', () => {
         selectedEpisode={1}
         goToEpisode
         closePopupFunction={() => {}}
+        isSelectedHomeContainer
       />,
     ).toJSON();
     expect(tree).toMatchSnapshot();
@@ -98,6 +100,7 @@ describe('HomeContainer: ', () => {
         selectedEpisode={1}
         goToEpisode={false}
         closePopupFunction={() => {}}
+        isSelectedHomeContainer
       />,
     ).toJSON();
     expect(tree).toMatchSnapshot();

--- a/src/components/series-detail/__snapshots__/series-container.test.js.snap
+++ b/src/components/series-detail/__snapshots__/series-container.test.js.snap
@@ -4,6 +4,7 @@ exports[`renders correctly 1`] = `
 <div
   className="series-container"
 >
-   hello all 
+   
+   
 </div>
 `;

--- a/src/components/series-detail/__snapshots__/series-container.test.js.snap
+++ b/src/components/series-detail/__snapshots__/series-container.test.js.snap
@@ -7,5 +7,8 @@ exports[`renders correctly 1`] = `
   <div>
     Side Panel
   </div>
+  <div
+    className="series-content"
+  />
 </div>
 `;

--- a/src/components/series-detail/__snapshots__/series-container.test.js.snap
+++ b/src/components/series-detail/__snapshots__/series-container.test.js.snap
@@ -5,7 +5,131 @@ exports[`renders correctly 1`] = `
   className="series-container"
 >
   <div
-    className="home-slider"
+    className="side-panel"
+  >
+    <ul
+      className="side-panel__option-list"
+    >
+      <li
+        className="side-panel__option"
+      >
+        <a
+          className="side-panel-card"
+          onClick={[Function]}
+          style={Object {}}
+        >
+          <svg
+            className="side-panel-card__icon side-panel-card__icon--x"
+            height="60"
+            width="60"
+          >
+            <circle
+              cx="30"
+              cy="30"
+              fill="white"
+              r="29"
+              stroke="silver"
+              strokeWidth="2"
+            />
+          </svg>
+          <span
+            className="side-panel-card__title"
+          >
+            Profile Name
+          </span>
+        </a>
+      </li>
+      <li
+        className="side-panel__option side-panel__option--active"
+      >
+        <a
+          className="side-panel-card side-panel-card--active"
+          onClick={[Function]}
+          style={Object {}}
+        >
+          <svg
+            className="side-panel-card__icon side-panel-card__icon--search-icon"
+            height="60"
+            width="60"
+          >
+            <circle
+              cx="30"
+              cy="30"
+              fill="white"
+              r="29"
+              stroke="silver"
+              strokeWidth="2"
+            />
+          </svg>
+          <span
+            className="side-panel-card__title"
+          >
+            Search
+          </span>
+        </a>
+      </li>
+      <li
+        className="side-panel__option"
+      >
+        <a
+          className="side-panel-card"
+          onClick={[Function]}
+          style={Object {}}
+        >
+          <svg
+            className="side-panel-card__icon side-panel-card__icon--home-icon"
+            height="60"
+            width="60"
+          >
+            <circle
+              cx="30"
+              cy="30"
+              fill="white"
+              r="29"
+              stroke="silver"
+              strokeWidth="2"
+            />
+          </svg>
+          <span
+            className="side-panel-card__title"
+          >
+            Home
+          </span>
+        </a>
+      </li>
+      <li
+        className="side-panel__option"
+      >
+        <a
+          className="side-panel-card"
+          onClick={[Function]}
+          style={Object {}}
+        >
+          <svg
+            className="side-panel-card__icon side-panel-card__icon--favorites-icon"
+            height="60"
+            width="60"
+          >
+            <circle
+              cx="30"
+              cy="30"
+              fill="white"
+              r="29"
+              stroke="silver"
+              strokeWidth="2"
+            />
+          </svg>
+          <span
+            className="side-panel-card__title"
+          >
+            Favorites
+          </span>
+        </a>
+      </li>
+    </ul>
+  </div>
+  <div
+    className="home-slider home-slider--selected"
   >
     <div
       className="slider-title"

--- a/src/components/series-detail/__snapshots__/series-container.test.js.snap
+++ b/src/components/series-detail/__snapshots__/series-container.test.js.snap
@@ -4,7 +4,22 @@ exports[`renders correctly 1`] = `
 <div
   className="series-container"
 >
-   
-   
+  <div
+    className="home-slider"
+  >
+    <div
+      className="slider-title"
+    >
+      Slider Title
+    </div>
+    <div
+      className="slider-items"
+      style={
+        Object {
+          "transform": "translate(0px, 0px)",
+        }
+      }
+    />
+  </div>
 </div>
 `;

--- a/src/components/series-detail/__snapshots__/series-container.test.js.snap
+++ b/src/components/series-detail/__snapshots__/series-container.test.js.snap
@@ -13,7 +13,7 @@ exports[`renders correctly 1`] = `
     <div
       className="slider-title"
     >
-      Slider Title
+      
     </div>
     <div
       className="slider-items"
@@ -40,7 +40,7 @@ exports[`renders correctly without episodeID 1`] = `
     <div
       className="slider-title"
     >
-      Slider Title
+      
     </div>
     <div
       className="slider-items"

--- a/src/components/series-detail/__snapshots__/series-container.test.js.snap
+++ b/src/components/series-detail/__snapshots__/series-container.test.js.snap
@@ -7,49 +7,5 @@ exports[`renders correctly 1`] = `
   <div>
     Side Panel
   </div>
-  <div
-    className="home-slider home-slider--selected"
-  >
-    <div
-      className="slider-title"
-    >
-      
-    </div>
-    <div
-      className="slider-items"
-      style={
-        Object {
-          "transform": "translate(0px, 0px)",
-        }
-      }
-    />
-  </div>
-</div>
-`;
-
-exports[`renders correctly without episodeID 1`] = `
-<div
-  className="series-container"
->
-  <div>
-    Side Panel
-  </div>
-  <div
-    className="home-slider home-slider--selected"
-  >
-    <div
-      className="slider-title"
-    >
-      
-    </div>
-    <div
-      className="slider-items"
-      style={
-        Object {
-          "transform": "translate(0px, 0px)",
-        }
-      }
-    />
-  </div>
 </div>
 `;

--- a/src/components/series-detail/__snapshots__/series-container.test.js.snap
+++ b/src/components/series-detail/__snapshots__/series-container.test.js.snap
@@ -4,129 +4,35 @@ exports[`renders correctly 1`] = `
 <div
   className="series-container"
 >
+  <div>
+    Side Panel
+  </div>
   <div
-    className="side-panel"
+    className="home-slider home-slider--selected"
   >
-    <ul
-      className="side-panel__option-list"
+    <div
+      className="slider-title"
     >
-      <li
-        className="side-panel__option"
-      >
-        <a
-          className="side-panel-card"
-          onClick={[Function]}
-          style={Object {}}
-        >
-          <svg
-            className="side-panel-card__icon side-panel-card__icon--x"
-            height="60"
-            width="60"
-          >
-            <circle
-              cx="30"
-              cy="30"
-              fill="white"
-              r="29"
-              stroke="silver"
-              strokeWidth="2"
-            />
-          </svg>
-          <span
-            className="side-panel-card__title"
-          >
-            Profile Name
-          </span>
-        </a>
-      </li>
-      <li
-        className="side-panel__option side-panel__option--active"
-      >
-        <a
-          className="side-panel-card side-panel-card--active"
-          onClick={[Function]}
-          style={Object {}}
-        >
-          <svg
-            className="side-panel-card__icon side-panel-card__icon--search-icon"
-            height="60"
-            width="60"
-          >
-            <circle
-              cx="30"
-              cy="30"
-              fill="white"
-              r="29"
-              stroke="silver"
-              strokeWidth="2"
-            />
-          </svg>
-          <span
-            className="side-panel-card__title"
-          >
-            Search
-          </span>
-        </a>
-      </li>
-      <li
-        className="side-panel__option"
-      >
-        <a
-          className="side-panel-card"
-          onClick={[Function]}
-          style={Object {}}
-        >
-          <svg
-            className="side-panel-card__icon side-panel-card__icon--home-icon"
-            height="60"
-            width="60"
-          >
-            <circle
-              cx="30"
-              cy="30"
-              fill="white"
-              r="29"
-              stroke="silver"
-              strokeWidth="2"
-            />
-          </svg>
-          <span
-            className="side-panel-card__title"
-          >
-            Home
-          </span>
-        </a>
-      </li>
-      <li
-        className="side-panel__option"
-      >
-        <a
-          className="side-panel-card"
-          onClick={[Function]}
-          style={Object {}}
-        >
-          <svg
-            className="side-panel-card__icon side-panel-card__icon--favorites-icon"
-            height="60"
-            width="60"
-          >
-            <circle
-              cx="30"
-              cy="30"
-              fill="white"
-              r="29"
-              stroke="silver"
-              strokeWidth="2"
-            />
-          </svg>
-          <span
-            className="side-panel-card__title"
-          >
-            Favorites
-          </span>
-        </a>
-      </li>
-    </ul>
+      Slider Title
+    </div>
+    <div
+      className="slider-items"
+      style={
+        Object {
+          "transform": "translate(0px, 0px)",
+        }
+      }
+    />
+  </div>
+</div>
+`;
+
+exports[`renders correctly without episodeID 1`] = `
+<div
+  className="series-container"
+>
+  <div>
+    Side Panel
   </div>
   <div
     className="home-slider home-slider--selected"

--- a/src/components/series-detail/series-container.css
+++ b/src/components/series-detail/series-container.css
@@ -1,3 +1,7 @@
 .series-container {
   display: block;
 }
+
+.series-content {
+  margin-left: 100px;
+}

--- a/src/components/series-detail/series-container.js
+++ b/src/components/series-detail/series-container.js
@@ -18,8 +18,8 @@ export type SeriesContainerProps = {
   },
 }
 export type SeriesContainerState = {
+  seriesTitle: string,
   episodes: Array<Object>,
-  series: Object,
   selectedEpisode: number,
   isSliderSelected: boolean,
   isSideBarSelected: boolean,
@@ -30,18 +30,17 @@ export type SeriesContainerState = {
 class SeriesContainer extends React.Component {
   static findEpisode(episodes: Array<Object>, expandedEpisodeID: string) {
     let foundEpisode = 0;
-    episodes.forEach((episode, index) => {
-      if (episode.id === Number(expandedEpisodeID)) {
-        foundEpisode = index;
-      }
-    });
+    if (expandedEpisodeID) {
+      foundEpisode = episodes.findIndex(episode => episode.id === Number(expandedEpisodeID));
+      return foundEpisode;
+    }
     return foundEpisode;
   }
   constructor(props: SeriesContainerProps) {
     super(props);
     this.state = {
       episodes: [],
-      series: {},
+      seriesTitle: '',
       selectedEpisode: 0,
       isSliderSelected: true,
       isSideBarSelected: false,
@@ -62,7 +61,7 @@ class SeriesContainer extends React.Component {
           SeriesContainer.findEpisode(
             series.published_episodes,
             this.props.location.query.expandedEpisode),
-        series,
+        seriesTitle: series.title,
       });
     });
   }
@@ -83,7 +82,7 @@ class SeriesContainer extends React.Component {
   handleReturnFromEpisode() {
     this.setState({ goToEpisodeDetail: false });
   }
-  handleKeyPress(event: Object) {
+  handleKeyPress(event: KeyboardEvent) {
     const {
       episodes,
       selectedEpisode,
@@ -95,7 +94,7 @@ class SeriesContainer extends React.Component {
         event.preventDefault();
         if (isSliderSelected && selectedEpisode !== 0) {
           (this: any).setState({
-            selectedEpisode: selectedEpisode -1,
+            selectedEpisode: selectedEpisode - 1,
           });
         } if (selectedEpisode === 0) {
           (this: any).setState({
@@ -107,9 +106,9 @@ class SeriesContainer extends React.Component {
         break;
       case 'ArrowRight':
         event.preventDefault();
-        if (isSliderSelected && selectedEpisode < episodes.length -1) {
+        if (isSliderSelected && selectedEpisode < episodes.length - 1) {
           (this: any).setState({
-            selectedEpisode: selectedEpisode +1,
+            selectedEpisode: selectedEpisode + 1,
           });
         } if (isSideBarSelected) {
           (this: any).setState({
@@ -132,12 +131,12 @@ class SeriesContainer extends React.Component {
 
   render() {
     const {
-      series,
       episodes,
       selectedEpisode,
       isSliderSelected,
       isSideBarSelected,
       goToEpisodeDetail,
+      seriesTitle,
     } = this.state;
     const selectedEpisodeData = episodes[selectedEpisode];
     const episodeDetailsContainer = goToEpisodeDetail && selectedEpisodeData ? (
@@ -163,8 +162,8 @@ class SeriesContainer extends React.Component {
         <Slider
           data={episodes}
           className="home-slider"
-          sliderTitle={series.title}
-          key={series.title}
+          sliderTitle={seriesTitle}
+          key={seriesTitle}
           isSelected={isSliderSelected}
           selectedEpisode={selectedEpisode}
         />

--- a/src/components/series-detail/series-container.js
+++ b/src/components/series-detail/series-container.js
@@ -8,6 +8,7 @@ export type SeriesContainerProps = {
 }
 export type SeriesContainerState = {
   episodes: Array<Object>,
+  series: Object,
 }
 
 class SeriesContainer extends React.Component {
@@ -15,18 +16,32 @@ class SeriesContainer extends React.Component {
     super(props);
     this.state = {
       episodes: [],
+      series: {},
     };
   }
   state: SeriesContainerState
   componentWillMount() {
     getSeriesByID(this.props.params.id)
     .then((series) => {
-      console.log(series);
+      this.setState({
+        episodes: series.published_episodes,
+        series,
+      });
+      // console.log(this.state.episodes);
     });
   }
   render() {
+    const episodes = this.state.episodes.map(data =>
+      (
+        <div
+          key={data.title}
+        >
+          {data.title}
+        </div>
+      ),
+    );
     return (
-      <div className="series-container"> hello all </div>
+      <div className="series-container"> {episodes} </div>
     );
   }
 }

--- a/src/components/series-detail/series-container.js
+++ b/src/components/series-detail/series-container.js
@@ -16,7 +16,6 @@ class SeriesContainer extends React.Component {
     this.state = {
       episodes: [],
     };
-    (this: any).hadnleSetSeriesID = (this: any).hadnleSetSeriesID.bind(this);
   }
   state: SeriesContainerState
   componentWillMount() {

--- a/src/components/series-detail/series-container.js
+++ b/src/components/series-detail/series-container.js
@@ -18,7 +18,7 @@ export type SeriesContainerProps = {
   },
 }
 export type SeriesContainerState = {
-  series: Object,
+  series: ?Object,
   selectedEpisode: number,
   isSliderSelected: boolean,
   isSideBarSelected: boolean,
@@ -30,7 +30,6 @@ class SeriesContainer extends React.Component {
   constructor(props: SeriesContainerProps) {
     super(props);
     this.state = {
-      // $FlowFixMe
       series: null,
       selectedEpisode: 0,
       isSliderSelected: true,
@@ -76,6 +75,7 @@ class SeriesContainer extends React.Component {
   handleKeyPress(event: KeyboardEvent) {
     const {
       series,
+      goToEpisodeDetail,
       selectedEpisode,
       isSliderSelected,
       isSideBarSelected,
@@ -83,7 +83,7 @@ class SeriesContainer extends React.Component {
     switch (event.code) {
       case 'ArrowLeft':
         event.preventDefault();
-        if (isSliderSelected && selectedEpisode !== 0) {
+        if (isSliderSelected && selectedEpisode !== 0 && !goToEpisodeDetail) {
           this.setState({
             selectedEpisode: selectedEpisode - 1,
           });
@@ -97,7 +97,8 @@ class SeriesContainer extends React.Component {
         break;
       case 'ArrowRight':
         event.preventDefault();
-        if (isSliderSelected && selectedEpisode < series.published_episodes.length - 1) {
+        if (isSliderSelected && series &&
+          selectedEpisode < series.published_episodes.length - 1 && !goToEpisodeDetail) {
           this.setState({
             selectedEpisode: selectedEpisode + 1,
           });
@@ -159,8 +160,10 @@ class SeriesContainer extends React.Component {
           isSelected={isSideBarSelected}
           user={{ id: 1, name: 'Profile Name', imgUrl: 'x' }}
         />
-        {slider}
-        {episodeDetailsContainer}
+        <div className="series-content">
+          {slider}
+          {episodeDetailsContainer}
+        </div>
       </div>
     );
   }

--- a/src/components/series-detail/series-container.js
+++ b/src/components/series-detail/series-container.js
@@ -1,8 +1,30 @@
 // @flow
 import React from 'react';
+import { getSeriesByID } from '../../api/fetch';
 import './series-container.css';
 
-class SeriesContainer extends React.Component {// eslint-disable-line
+export type SeriesContainerProps = {
+  params: Object,
+}
+export type SeriesContainerState = {
+  episodes: Array<Object>,
+}
+
+class SeriesContainer extends React.Component {
+  constructor(props: SeriesContainerProps) {
+    super(props);
+    this.state = {
+      episodes: [],
+    };
+    (this: any).hadnleSetSeriesID = (this: any).hadnleSetSeriesID.bind(this);
+  }
+  state: SeriesContainerState
+  componentWillMount() {
+    getSeriesByID(this.props.params.id)
+    .then((series) => {
+      console.log(series);
+    });
+  }
   render() {
     return (
       <div className="series-container"> hello all </div>

--- a/src/components/series-detail/series-container.js
+++ b/src/components/series-detail/series-container.js
@@ -1,8 +1,9 @@
 // @flow
 import React from 'react';
+import Slider from '../slider/slider';
+import SidePanel from '../side-panel/side-panel';
 import { getSeriesByID } from '../../api/fetch';
 import './series-container.css';
-import Slider from '../slider/slider';
 
 export type SeriesContainerProps = {
   params: {
@@ -12,8 +13,9 @@ export type SeriesContainerProps = {
 export type SeriesContainerState = {
   episodes: Array<Object>,
   series: Object,
-  isSliderSelected: boolean,
   selectedEpisode: number,
+  isSliderSelected: boolean,
+  isSideBarSelected: boolean,
 }
 
 class SeriesContainer extends React.Component {
@@ -24,6 +26,7 @@ class SeriesContainer extends React.Component {
       series: {},
       selectedEpisode: 0,
       isSliderSelected: true,
+      isSideBarSelected: false,
     };
     (this: any).handleKeyPress = (this: any).handleKeyPress.bind(this);
   }
@@ -31,7 +34,7 @@ class SeriesContainer extends React.Component {
   componentWillMount() {
     getSeriesByID(this.props.params.id)
     .then((series) => {
-      this.setState({
+      (this: any).setState({
         episodes: series.published_episodes,
         series,
       });
@@ -40,12 +43,16 @@ class SeriesContainer extends React.Component {
   componentDidMount() {
     document.addEventListener('keydown', this.handleKeyPress);
   }
+  componentWillUnmount() {
+    document.removeEventListener('keydown', this.handleKeyPress);
+  }
   handleKeyPress(event: Object) {
     const {
       episodes,
       selectedEpisode,
       isSliderSelected,
-    } = (this: any).state;
+      isSideBarSelected,
+    } = this.state;
     switch (event.code) {
       case 'ArrowUp':
         break;
@@ -56,6 +63,12 @@ class SeriesContainer extends React.Component {
           (this: any).setState({
             selectedEpisode: selectedEpisode -1,
           });
+        } if (selectedEpisode === 0) {
+          this.setState({
+            isSliderSelected: false,
+            isSideBarSelected: true,
+          });
+          console.log('sidebar');
         }
         break;
       case 'ArrowRight':
@@ -63,7 +76,13 @@ class SeriesContainer extends React.Component {
           (this: any).setState({
             selectedEpisode: selectedEpisode +1,
           });
+        } if (isSideBarSelected) {
+          this.setState({
+            isSliderSelected: true,
+            isSideBarSelected: false,
+          });
         }
+        console.log('slider');
         break;
       default:
     }
@@ -72,12 +91,16 @@ class SeriesContainer extends React.Component {
   render() {
     return (
       <div className="series-container">
+        <SidePanel
+          isSelected={this.state.isSideBarSelected}
+          user={{ id: 1, name: 'Profile Name', imgUrl: 'x' }}
+        />
         <Slider
           data={this.state.episodes}
           className="home-slider"
           sliderTitle={this.state.series.title}
           key={this.state.series.title}
-          isSliderSelected={this.state.isSliderSelected}
+          isSelected={this.state.isSliderSelected}
           selectedEpisode={this.state.selectedEpisode}
         />
       </div>

--- a/src/components/series-detail/series-container.js
+++ b/src/components/series-detail/series-container.js
@@ -49,7 +49,7 @@ class SeriesContainer extends React.Component {
       const expandedEpisodeId = Number(this.props.location.query.expandedEpisode);
       const foundPosition = series.published_episodes.findIndex(
       episode => episode.id === expandedEpisodeId);
-      (this: any).setState({
+      this.setState({
         series,
         selectedEpisode: foundPosition < 0 ? 0 : foundPosition,
       });
@@ -65,7 +65,7 @@ class SeriesContainer extends React.Component {
   }
   handleExpand() {
     if (this.props.location.query.expandedEpisode) {
-      (this: any).setState({
+      this.setState({
         goToEpisodeDetail: true,
       });
     }
@@ -84,11 +84,11 @@ class SeriesContainer extends React.Component {
       case 'ArrowLeft':
         event.preventDefault();
         if (isSliderSelected && selectedEpisode !== 0) {
-          (this: any).setState({
+          this.setState({
             selectedEpisode: selectedEpisode - 1,
           });
         } if (selectedEpisode === 0) {
-          (this: any).setState({
+          this.setState({
             isSliderSelected: false,
             isSideBarSelected: true,
             goToEpisodeDetail: false,
@@ -98,11 +98,11 @@ class SeriesContainer extends React.Component {
       case 'ArrowRight':
         event.preventDefault();
         if (isSliderSelected && selectedEpisode < series.published_episodes.length - 1) {
-          (this: any).setState({
+          this.setState({
             selectedEpisode: selectedEpisode + 1,
           });
         } if (isSideBarSelected) {
-          (this: any).setState({
+          this.setState({
             isSliderSelected: true,
             isSideBarSelected: false,
           });
@@ -110,7 +110,7 @@ class SeriesContainer extends React.Component {
         break;
       case 'Enter':
         if (isSliderSelected) {
-          (this: any).setState({ goToEpisodeDetail: true });
+          this.setState({ goToEpisodeDetail: true });
         }
         break;
       case 'Backspace':

--- a/src/components/series-detail/series-container.js
+++ b/src/components/series-detail/series-container.js
@@ -2,13 +2,18 @@
 import React from 'react';
 import { getSeriesByID } from '../../api/fetch';
 import './series-container.css';
+import Slider from '../slider/slider';
 
 export type SeriesContainerProps = {
-  params: Object,
+  params: {
+    id: number,
+  }
 }
 export type SeriesContainerState = {
   episodes: Array<Object>,
   series: Object,
+  isSliderSelected: boolean,
+  selectedEpisode: number,
 }
 
 class SeriesContainer extends React.Component {
@@ -17,7 +22,10 @@ class SeriesContainer extends React.Component {
     this.state = {
       episodes: [],
       series: {},
+      selectedEpisode: 0,
+      isSliderSelected: true,
     };
+    (this: any).handleKeyPress = (this: any).handleKeyPress.bind(this);
   }
   state: SeriesContainerState
   componentWillMount() {
@@ -27,21 +35,52 @@ class SeriesContainer extends React.Component {
         episodes: series.published_episodes,
         series,
       });
-      // console.log(this.state.episodes);
     });
   }
+  componentDidMount() {
+    document.addEventListener('keydown', this.handleKeyPress);
+  }
+  handleKeyPress(event: Object) {
+    const {
+      episodes,
+      selectedEpisode,
+      isSliderSelected,
+    } = (this: any).state;
+    switch (event.code) {
+      case 'ArrowUp':
+        break;
+      case 'ArrowDown':
+        break;
+      case 'ArrowLeft':
+        if (isSliderSelected && selectedEpisode !== 0) {
+          (this: any).setState({
+            selectedEpisode: selectedEpisode -1,
+          });
+        }
+        break;
+      case 'ArrowRight':
+        if (isSliderSelected && selectedEpisode < episodes.length -1) {
+          (this: any).setState({
+            selectedEpisode: selectedEpisode +1,
+          });
+        }
+        break;
+      default:
+    }
+  }
+
   render() {
-    const episodes = this.state.episodes.map(data =>
-      (
-        <div
-          key={data.title}
-        >
-          {data.title}
-        </div>
-      ),
-    );
     return (
-      <div className="series-container"> {episodes} </div>
+      <div className="series-container">
+        <Slider
+          data={this.state.episodes}
+          className="home-slider"
+          sliderTitle={this.state.series.title}
+          key={this.state.series.title}
+          isSliderSelected={this.state.isSliderSelected}
+          selectedEpisode={this.state.selectedEpisode}
+        />
+      </div>
     );
   }
 }

--- a/src/components/series-detail/series-container.test.js
+++ b/src/components/series-detail/series-container.test.js
@@ -3,7 +3,28 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 import SeriesContainer from './series-container';
 
+// const mockData = [
+//   {
+//     title: 'Ocean',
+//     items: [
+//       {
+//         id: 1,
+//         title: 'xxx',
+//         type: 'yyy',
+//       },
+//       {
+//         id: 2,
+//         title: 'aaa',
+//         type: 'bbb',
+//       },
+//     ],
+//   },
+// ];
+
 test('renders correctly', () => {
-  const tree : string = renderer.create(<SeriesContainer />).toJSON();
+  const tree : string = renderer.create(
+    <SeriesContainer
+      params={{ id: 50 }}
+    />).toJSON();
   expect(tree).toMatchSnapshot();
 });

--- a/src/components/series-detail/series-container.test.js
+++ b/src/components/series-detail/series-container.test.js
@@ -82,12 +82,10 @@ test('Series detail navigation works', () => {
   expect(seriesContainer.state().isSliderSelected).toEqual(true);
   expect(seriesContainer.state().isSideBarSelected).toEqual(false);
   expect(seriesContainer.state().selectedEpisode).toEqual(0);
-  // [0,1]
+  expect(seriesContainer.state().goToEpisodeDetail).toEqual(true);
+  // [0,0]
   connectEvent(event, 'ArrowRight', seriesContainer);
-  expect(seriesContainer.state().selectedEpisode).toEqual(1);
-  connectEvent(event, 'ArrowRight', seriesContainer);
-  // [0,1]
-  expect(seriesContainer.state().selectedEpisode).toEqual(1);
+  expect(seriesContainer.state().selectedEpisode).toEqual(0);
   // [0,0]
   connectEvent(event, 'ArrowLeft', seriesContainer);
   expect(seriesContainer.state().selectedEpisode).toEqual(0);
@@ -96,17 +94,23 @@ test('Series detail navigation works', () => {
   expect(seriesContainer.state().isSliderSelected).toEqual(false);
   expect(seriesContainer.state().isSideBarSelected).toEqual(true);
   expect(seriesContainer.state().goToEpisodeDetail).toEqual(false);
+  connectEvent(event, 'Enter', seriesContainer);
+  seriesContainer.setState({ goToEpisodeDetail: false });
   // slider is selected
   connectEvent(event, 'ArrowRight', seriesContainer);
   expect(seriesContainer.state().isSliderSelected).toEqual(true);
   expect(seriesContainer.state().isSideBarSelected).toEqual(false);
+  expect(seriesContainer.state().selectedEpisode).toEqual(0);
   // show pop up
   connectEvent(event, 'Enter', seriesContainer);
-  expect(seriesContainer.state().goToEpisodeDetail).toEqual(true);
-  // unselect slider
-  seriesContainer.setState({ isSliderSelected: false });
-  // cant open pop up
-  connectEvent(event, 'Enter', seriesContainer);
+  seriesContainer.setState({ goToEpisodeDetail: false });
+  expect(seriesContainer.state().selectedEpisode).toEqual(0);
+  expect(seriesContainer.state().goToEpisodeDetail).toEqual(false);
+  connectEvent(event, 'ArrowRight', seriesContainer);
+  expect(seriesContainer.state().selectedEpisode).toEqual(1);
+  connectEvent(event, 'ArrowRight', seriesContainer);
+  connectEvent(event, 'ArrowLeft', seriesContainer);
+  expect(seriesContainer.state().selectedEpisode).toEqual(0);
   connectEvent(event, 'Backspace', seriesContainer);
   jest.fn(() => {});
   connectEvent(event, 'Space', seriesContainer);

--- a/src/components/series-detail/series-container.test.js
+++ b/src/components/series-detail/series-container.test.js
@@ -6,19 +6,53 @@ import SeriesContainer from './series-container';
 
 const dummySliderItems = [
   {
-    title: 'Episode 1 Title',
-    type: 'Episode 1',
+    id: 119,
+    title: 'Saving Corals',
+    thumbnail: {
+      url: 'https://cdn.twivel.io/uploads/economist/episode/thumbnail/119/episode_875X480.jpg',
+    },
+    type: 'Episode',
   },
   {
-    title: 'Episode 2 Title',
-    type: 'Episode 2',
+    id: 141,
+    title: 'The deep ocean is the final frontier on planet Earth',
+    thumbnail: {
+      url: 'https://cdn.twivel.io/uploads/economist/episode/thumbnail/141/episode_875X480.jpg',
+    },
+    type: 'Episode',
   },
 ];
+
+jest.mock('../side-panel/side-panel', () =>
+  jest.fn(() => <div>Side Panel</div>),
+);
+
+jest.mock('../episode-selected/episode-selected', () =>
+  jest.fn(() => <div>Episode selected</div>),
+);
 
 test('renders correctly', () => {
   const tree : string = renderer.create(
     <SeriesContainer
       params={{ id: 50 }}
+      location={{
+        query: {
+          expandedEpisode: '100',
+        },
+      }}
+    />).toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test('renders correctly without episodeID', () => {
+  const tree : string = renderer.create(
+    <SeriesContainer
+      params={{ id: 50 }}
+      location={{
+        query: {
+          expandedEpisode: '',
+        },
+      }}
     />).toJSON();
   expect(tree).toMatchSnapshot();
 });
@@ -30,31 +64,53 @@ function connectEvent(event, type, wrapper) {
   app.handleKeyPress(event);
 }
 
-
 test('Series detail navigation works', () => {
   const app = mount(
     <SeriesContainer
       params={{ id: 50 }}
+      location={{
+        query: {
+          expandedEpisode: '119',
+        },
+      }}
     />);
   const event = new Event('keyDown');
+  app.setState({ episodes: dummySliderItems });
   expect(app.state().isSliderSelected).toEqual(true);
   expect(app.state().isSideBarSelected).toEqual(false);
   expect(app.state().selectedEpisode).toEqual(0);
-  app.setState({ episodes: dummySliderItems });
-  connectEvent(event, 'ArrowUp', app);
-  connectEvent(event, 'ArrowDown', app);
+  // [0,1]
   connectEvent(event, 'ArrowRight', app);
   expect(app.state().selectedEpisode).toEqual(1);
   connectEvent(event, 'ArrowRight', app);
+  // [0,1]
   expect(app.state().selectedEpisode).toEqual(1);
+  // [0,0]
   connectEvent(event, 'ArrowLeft', app);
   expect(app.state().selectedEpisode).toEqual(0);
+  // sidePanel is selected
   connectEvent(event, 'ArrowLeft', app);
   expect(app.state().isSliderSelected).toEqual(false);
   expect(app.state().isSideBarSelected).toEqual(true);
+  expect(app.state().goToEpisodeDetail).toEqual(false);
+  // slider is selected
   connectEvent(event, 'ArrowRight', app);
   expect(app.state().isSliderSelected).toEqual(true);
   expect(app.state().isSideBarSelected).toEqual(false);
+  // show pop up
+  connectEvent(event, 'Enter', app);
+  expect(app.state().goToEpisodeDetail).toEqual(true);
+  // unselect slider
+  app.setState({ isSliderSelected: false });
+  // cant open pop up
+  connectEvent(event, 'Enter', app);
+  connectEvent(event, 'Backspace', app);
+  jest.fn(() => {});
   connectEvent(event, 'Space', app);
+  const foundEpisode = SeriesContainer.findEpisode(dummySliderItems, '141');
+  expect(foundEpisode).toEqual(1);
+  const seriesContainer: Object = app.instance();
+  seriesContainer.handleReturnFromEpisode();
+  expect(app.state().goToEpisodeDetail).toEqual(false);
   app.unmount();
 });

--- a/src/components/series-detail/series-container.test.js
+++ b/src/components/series-detail/series-container.test.js
@@ -30,6 +30,7 @@ function connectEvent(event, type, wrapper) {
   app.handleKeyPress(event);
 }
 
+
 test('Series detail navigation works', () => {
   const app = mount(
     <SeriesContainer
@@ -37,6 +38,7 @@ test('Series detail navigation works', () => {
     />);
   const event = new Event('keyDown');
   expect(app.state().isSliderSelected).toEqual(true);
+  expect(app.state().isSideBarSelected).toEqual(false);
   expect(app.state().selectedEpisode).toEqual(0);
   app.setState({ episodes: dummySliderItems });
   connectEvent(event, 'ArrowUp', app);
@@ -48,6 +50,11 @@ test('Series detail navigation works', () => {
   connectEvent(event, 'ArrowLeft', app);
   expect(app.state().selectedEpisode).toEqual(0);
   connectEvent(event, 'ArrowLeft', app);
-  expect(app.state().selectedEpisode).toEqual(0);
+  expect(app.state().isSliderSelected).toEqual(false);
+  expect(app.state().isSideBarSelected).toEqual(true);
+  connectEvent(event, 'ArrowRight', app);
+  expect(app.state().isSliderSelected).toEqual(true);
+  expect(app.state().isSideBarSelected).toEqual(false);
   connectEvent(event, 'Space', app);
+  app.unmount();
 });

--- a/src/components/series-detail/series-container.test.js
+++ b/src/components/series-detail/series-container.test.js
@@ -60,12 +60,12 @@ test('renders correctly without episodeID', () => {
 function connectEvent(event, type, wrapper) {
   const changedEvent: Object = event;
   changedEvent.code = type;
-  const app: Object = wrapper.instance();
-  app.handleKeyPress(event);
+  const seriesContainer: Object = wrapper.instance();
+  seriesContainer.handleKeyPress(event);
 }
 
 test('Series detail navigation works', () => {
-  const app = mount(
+  const seriesContainer = mount(
     <SeriesContainer
       params={{ id: 50 }}
       location={{
@@ -75,42 +75,41 @@ test('Series detail navigation works', () => {
       }}
     />);
   const event = new Event('keyDown');
-  app.setState({ episodes: dummySliderItems });
-  expect(app.state().isSliderSelected).toEqual(true);
-  expect(app.state().isSideBarSelected).toEqual(false);
-  expect(app.state().selectedEpisode).toEqual(0);
+  seriesContainer.setState({ episodes: dummySliderItems });
+  expect(seriesContainer.state().isSliderSelected).toEqual(true);
+  expect(seriesContainer.state().isSideBarSelected).toEqual(false);
+  expect(seriesContainer.state().selectedEpisode).toEqual(0);
   // [0,1]
-  connectEvent(event, 'ArrowRight', app);
-  expect(app.state().selectedEpisode).toEqual(1);
-  connectEvent(event, 'ArrowRight', app);
+  connectEvent(event, 'ArrowRight', seriesContainer);
+  expect(seriesContainer.state().selectedEpisode).toEqual(1);
+  connectEvent(event, 'ArrowRight', seriesContainer);
   // [0,1]
-  expect(app.state().selectedEpisode).toEqual(1);
+  expect(seriesContainer.state().selectedEpisode).toEqual(1);
   // [0,0]
-  connectEvent(event, 'ArrowLeft', app);
-  expect(app.state().selectedEpisode).toEqual(0);
+  connectEvent(event, 'ArrowLeft', seriesContainer);
+  expect(seriesContainer.state().selectedEpisode).toEqual(0);
   // sidePanel is selected
-  connectEvent(event, 'ArrowLeft', app);
-  expect(app.state().isSliderSelected).toEqual(false);
-  expect(app.state().isSideBarSelected).toEqual(true);
-  expect(app.state().goToEpisodeDetail).toEqual(false);
+  connectEvent(event, 'ArrowLeft', seriesContainer);
+  expect(seriesContainer.state().isSliderSelected).toEqual(false);
+  expect(seriesContainer.state().isSideBarSelected).toEqual(true);
+  expect(seriesContainer.state().goToEpisodeDetail).toEqual(false);
   // slider is selected
-  connectEvent(event, 'ArrowRight', app);
-  expect(app.state().isSliderSelected).toEqual(true);
-  expect(app.state().isSideBarSelected).toEqual(false);
+  connectEvent(event, 'ArrowRight', seriesContainer);
+  expect(seriesContainer.state().isSliderSelected).toEqual(true);
+  expect(seriesContainer.state().isSideBarSelected).toEqual(false);
   // show pop up
-  connectEvent(event, 'Enter', app);
-  expect(app.state().goToEpisodeDetail).toEqual(true);
+  connectEvent(event, 'Enter', seriesContainer);
+  expect(seriesContainer.state().goToEpisodeDetail).toEqual(true);
   // unselect slider
-  app.setState({ isSliderSelected: false });
+  seriesContainer.setState({ isSliderSelected: false });
   // cant open pop up
-  connectEvent(event, 'Enter', app);
-  connectEvent(event, 'Backspace', app);
+  connectEvent(event, 'Enter', seriesContainer);
+  connectEvent(event, 'Backspace', seriesContainer);
   jest.fn(() => {});
-  connectEvent(event, 'Space', app);
+  connectEvent(event, 'Space', seriesContainer);
   const foundEpisode = SeriesContainer.findEpisode(dummySliderItems, '141');
   expect(foundEpisode).toEqual(1);
-  const seriesContainer: Object = app.instance();
-  seriesContainer.handleReturnFromEpisode();
-  expect(app.state().goToEpisodeDetail).toEqual(false);
-  app.unmount();
+  const seriesContainerInstance: Object = seriesContainer.instance();
+  seriesContainerInstance.handleReturnFromEpisode();
+  seriesContainer.unmount();
 });

--- a/src/components/series-detail/series-container.test.js
+++ b/src/components/series-detail/series-container.test.js
@@ -110,8 +110,6 @@ test('Series detail navigation works', () => {
   connectEvent(event, 'Backspace', seriesContainer);
   jest.fn(() => {});
   connectEvent(event, 'Space', seriesContainer);
-  // const foundEpisode = SeriesContainer.findEpisode(dummySliderItems, '141');
-  // expect(foundEpisode).toEqual(1);
   const seriesContainerInstance: Object = seriesContainer.instance();
   seriesContainerInstance.handleReturnFromEpisode();
   seriesContainer.unmount();
@@ -130,7 +128,7 @@ test('Series fetch', () => {
         },
       }}
     />);
-    // $FlowFixMe
+  // $FlowFixMe
   expect(fetches.getSeriesByID.mock.calls.length).toEqual(1);
   mount(
     <SeriesContainer
@@ -141,6 +139,6 @@ test('Series fetch', () => {
         },
       }}
     />);
-    // $FlowFixMe
+  // $FlowFixMe
   expect(fetches.getSeriesByID.mock.calls.length).toEqual(2);
 });

--- a/src/components/series-detail/series-container.test.js
+++ b/src/components/series-detail/series-container.test.js
@@ -1,25 +1,19 @@
 // @flow
 import React from 'react';
 import renderer from 'react-test-renderer';
+import { mount } from 'enzyme';
 import SeriesContainer from './series-container';
 
-// const mockData = [
-//   {
-//     title: 'Ocean',
-//     items: [
-//       {
-//         id: 1,
-//         title: 'xxx',
-//         type: 'yyy',
-//       },
-//       {
-//         id: 2,
-//         title: 'aaa',
-//         type: 'bbb',
-//       },
-//     ],
-//   },
-// ];
+const dummySliderItems = [
+  {
+    title: 'Episode 1 Title',
+    type: 'Episode 1',
+  },
+  {
+    title: 'Episode 2 Title',
+    type: 'Episode 2',
+  },
+];
 
 test('renders correctly', () => {
   const tree : string = renderer.create(
@@ -27,4 +21,33 @@ test('renders correctly', () => {
       params={{ id: 50 }}
     />).toJSON();
   expect(tree).toMatchSnapshot();
+});
+
+function connectEvent(event, type, wrapper) {
+  const changedEvent: Object = event;
+  changedEvent.code = type;
+  const app: Object = wrapper.instance();
+  app.handleKeyPress(event);
+}
+
+test('Series detail navigation works', () => {
+  const app = mount(
+    <SeriesContainer
+      params={{ id: 50 }}
+    />);
+  const event = new Event('keyDown');
+  expect(app.state().isSliderSelected).toEqual(true);
+  expect(app.state().selectedEpisode).toEqual(0);
+  app.setState({ episodes: dummySliderItems });
+  connectEvent(event, 'ArrowUp', app);
+  connectEvent(event, 'ArrowDown', app);
+  connectEvent(event, 'ArrowRight', app);
+  expect(app.state().selectedEpisode).toEqual(1);
+  connectEvent(event, 'ArrowRight', app);
+  expect(app.state().selectedEpisode).toEqual(1);
+  connectEvent(event, 'ArrowLeft', app);
+  expect(app.state().selectedEpisode).toEqual(0);
+  connectEvent(event, 'ArrowLeft', app);
+  expect(app.state().selectedEpisode).toEqual(0);
+  connectEvent(event, 'Space', app);
 });

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ import './index.css';
 
 ReactDOM.render((
   <Router history={browserHistory}>
-    <Route path="/series" component={SeriesDetail} />
+    <Route path="/series/:id" component={SeriesDetail} />
     <Route path="/" component={App} />
     <Route path="/:selectedEpisodeId" component={App} />
     <Route path="/watch/:id" component={VideoPlayerContainer} />


### PR DESCRIPTION
You should know navigate to detail series page when you press on a first episode in a selected slider or when you open some other episode in the slider an press enter on a learn more button.
When you are already on the series detail page you should know to navigate between sidePanel and slider by pressing left and right keyboard. 

On my opinion there is unreadable css, and names of classes in selected-episode page and it should be refactor.