### PR TITLE
history

### DIFF
--- a/src/components/series-detail/series-container.js
+++ b/src/components/series-detail/series-container.js
@@ -199,7 +199,7 @@ class SeriesContainer extends React.Component {
         break;
       case 'Backspace':
         if (!goToEpisodeDetail) {
-          browserHistory.goBack();
+          browserHistory.push('/');
         }
         break;
       default:


### PR DESCRIPTION
When you enter whole link to video for example "http://localhost:3000/series/5?expandedEpisode=176"
and when you press backspace you should to be redirected to home page.