### PR TITLE
videoplayer on expand reset time and stuff like that

### DIFF
--- a/src/components/video-player-container/parts/video-player.js
+++ b/src/components/video-player-container/parts/video-player.js
@@ -97,12 +97,18 @@ class VideoPlayer extends React.Component {
     } = this.props;
     (this: any).player = videojs((this: any).videoNode, { ...videoJsOptions(videoUrl) });
     (this: any).player.muted(!isVideoExpanded);
-    (this: any).videoSaver = VideoPlayer.createVideoSaver((this: any).player, videoID);
+    if (isVideoExpanded) {
+      (this: any).videoSaver = VideoPlayer.createVideoSaver((this: any).player, videoID);
+    }
     document.addEventListener('keydown', this.handleKeyPress);
   }
-  componentDidUpdate() {
+  componentDidUpdate(prevProps: VideoPlayerPropsType) {
     if ((this: any).player) {
       (this: any).player.muted(!this.props.isVideoExpanded);
+    }
+    if (!prevProps.isVideoExpanded && this.props.isVideoExpanded) {
+      this.handleVideoLoad();
+      (this: any).videoSaver = VideoPlayer.createVideoSaver((this: any).player, this.props.videoID);
     }
   }
   componentWillUnmount() {
@@ -242,11 +248,17 @@ class VideoPlayer extends React.Component {
     }
   }
   handleVideoLoad() {
-    const { videoID: id } = this.props;
+    const {
+      videoID: id,
+      isVideoExpanded,
+    } = this.props;
     const lagTime = 5;
     const lastTimeProgress: number = getProgressTimeById(id);
     const videoLengthSecs = Math.round((this: any).player.duration());
-    const timeProgressSecs = Math.round((videoLengthSecs * (lastTimeProgress / 100)) - lagTime);
+    const defaultTimeStamp = Math.round(videoLengthSecs / 3);
+    const timeProgressSecs = isVideoExpanded ?
+      Math.round((videoLengthSecs * (lastTimeProgress / 100)) - lagTime):
+      defaultTimeStamp;
     (this: any).player.currentTime(timeProgressSecs);
   }
   handleEndReached() {

--- a/src/components/video-player-container/parts/video-player.test.js
+++ b/src/components/video-player-container/parts/video-player.test.js
@@ -215,6 +215,22 @@ test('videoPlayer navigation works for WEBOS TV', () => {
   connectEvent(event, 8, app);
   connectEvent(event, 'Space', app);
 });
+test('videoPlayer expanding works', () => {
+  const app = mount(
+    <VideoPlayer
+      videoUrl="https://cdn-films.economist.com/DW/MAY01_REV/MTMYSCivil.m3u8"
+      isVideoExpanded={false}
+      episodeTitle="hello"
+      posterImage={null}
+      videoID={5}
+      handleVideoExpansion={() => {}}
+    />,
+  );
+  expect(app.props().isVideoExpanded).toEqual(false);
+  app.setProps({ isVideoExpanded: true });
+  expect(app.props().isVideoExpanded).toEqual(true);
+  expect(app.state().timeProgress).toEqual(0);
+});
 test('Video progress saves properly', () => {
   // $FlowFixMe
   storage.saveVideoProgress = jest.fn();


### PR DESCRIPTION
This PR modifies the Video Player component so it plays from 33.3% time when it's not expanded ( in the component episode-selected, like a teaser shot ), and when it is expanded, it starts to save the actual progress and check in the local storage, if it has some info about the given video. If it isn't present in the local storage, then it starts from 0sec, otherwise from the saved timestamp.